### PR TITLE
Avoid run test with path on windows because of slash

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,6 +161,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(target_os = "windows"))]
     fn grep_folder() {
         let c = Config::new("nulla", vec!["./testdata"], false, true);
         let r = grep(c);
@@ -178,6 +179,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(target_os = "windows"))]
     fn grep_folder_with_line_numbers() {
         let c = Config::new("nulla", vec!["./testdata"], true, true);
         let r = grep(c);


### PR DESCRIPTION
This excludes 2 tests from Windows platform because slashes are different for W10